### PR TITLE
fix: event not safe for net

### DIFF
--- a/bridge/nd/client.lua
+++ b/bridge/nd/client.lua
@@ -25,7 +25,7 @@ function bridge.doesPlayerHaveJob(player, job)
 end
 
 
-AddEventHandler("ND:characterUnloaded", function()
+RegisterNetEvent("ND:characterUnloaded", function()
     TriggerEvent("ND_Police:playerUnloaded")
 end)
 


### PR DESCRIPTION
fixes an `event was not safe for net` error that happens when you change your character

*fixes #14*